### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Lint
 
+permissions:
+  contents: read
+
 on:
   # Trigger the workflow on push or pull request,
   # but only for the main branch


### PR DESCRIPTION
Potential fix for [https://github.com/dezh-tech/sea-snail/security/code-scanning/1](https://github.com/dezh-tech/sea-snail/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only needs to read the repository's contents to run linters, we will set `contents: read`. This ensures that the workflow does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
